### PR TITLE
Change e-mail-address to email-address in CSS

### DIFF
--- a/sass/sections/manage/forms/_user-forms.sass
+++ b/sass/sections/manage/forms/_user-forms.sass
@@ -8,11 +8,11 @@
     +omega(24)
     +leader(.25)
 
-  .e-mail-address-field, .roles-field, .form-actions
+  .email-address-field, .roles-field, .form-actions
     +full(24)
     +suffix(6,24)
 
-  .username-field, .e-mail-address-field, .roles-field
+  .username-field, .email-address-field, .roles-field
     .type
       +columns(6,18)
     .value, .errorlist

--- a/static/css/screen.css
+++ b/static/css/screen.css
@@ -4218,17 +4218,17 @@ h2 + .select-env-link:active, .selectenvhead + .select-env-link:active {
   #margin-left: -1em;
   margin-top: 0.375em;
 }
-.user-form .e-mail-address-field, .user-form .roles-field, .user-form .form-actions {
+.user-form .email-address-field, .user-form .roles-field, .user-form .form-actions {
   clear: both;
   padding-right: 25.263%;
 }
-.user-form .username-field .type, .user-form .e-mail-address-field .type, .user-form .roles-field .type {
+.user-form .username-field .type, .user-form .email-address-field .type, .user-form .roles-field .type {
   display: inline;
   float: left;
   width: 32.394%;
   margin-right: 1.408%;
 }
-.user-form .username-field .value, .user-form .username-field .errorlist, .user-form .e-mail-address-field .value, .user-form .e-mail-address-field .errorlist, .user-form .roles-field .value, .user-form .roles-field .errorlist {
+.user-form .username-field .value, .user-form .username-field .errorlist, .user-form .email-address-field .value, .user-form .email-address-field .errorlist, .user-form .roles-field .value, .user-form .roles-field .errorlist {
   display: inline;
   float: left;
   width: 66.197%;


### PR DESCRIPTION
There was a problem where an administrator could not click on the
username field to enter a username on the manage user screen. This was
caused by the email field's class being `email-address-field` while the CSS
was referring to `e-mail-address-field`. Since the style rules were not
applied correctly, the email field "overlapped" the username field. This
changes the CSS rules to match the correct `email-address-field` class.

@EricWorkman @mjhoffman65 @clymerrm Addresses issue #2 