### PR TITLE
Add a basic confirmation dialog on deletes

### DIFF
--- a/static/js/listpages.js
+++ b/static/js/listpages.js
@@ -58,6 +58,11 @@ var MT = (function (MT, $) {
                     },
                     data = {};
                 data[button.attr('name')] = button.val();
+                if (data.hasOwnProperty('action-delete')) {
+                    if (!confirm('Are you sure you want to delete this item?')) {
+                        return;
+                    }
+                }
                 replace.loadingOverlay();
                 $.ajax(url, {
                     type: method,


### PR DESCRIPTION
Whenever the delete button is clicked in a list view, the user will
now see a basic confirmation dialog box to allow them to either continue
with the delete action or to abandon it.

@craigmichaelmartin @EricWorkman @clymerrm Addresses #3.

@craigmichaelmartin I'm sure there is a much more intelligent way of doing this, but I don't want you to have to dig through the JavaScript on something you're not supposed to be working on. If you can spot a way of doing this better in a couple of minutes, please let me know.